### PR TITLE
allow var names in network files

### DIFF
--- a/netZooM/panda/panda_run.m
+++ b/netZooM/panda/panda_run.m
@@ -153,7 +153,9 @@ function [AgNet,TFNames,GeneNames]=panda_run(lib_path, exp_file, motif_file, ppi
             % transform Exp to table to save sample names
             ExpTbl = array2table(Exp,'RowNames',SampleNames(2:end));
             save(fullfile(save_temp, 'expression.transposed.mat'), 'ExpTbl', '-v7.3');  % 2G+
-            save(fullfile(save_temp, 'motif.normalized.mat'), 'RegNet', '-v6');  % fast
+            % transform RegNet to table to save gene and tf names
+            RegNetTbl = array2table(RegNet,'RowNames',TFNames,'VariableNames',GeneNames);
+            save(fullfile(save_temp, 'motif.normalized.mat'), 'RegNetTbl', '-v6');  % fast
             save(fullfile(save_temp, 'ppi.normalized.mat'), 'TFCoop', '-v6');  % fast
         toc
     end

--- a/netZooM/tools/processData.m
+++ b/netZooM/tools/processData.m
@@ -23,7 +23,7 @@ function [Exp,RegNet,TFCoop,TFNames,GeneNames,SampleNames]=processData(exp_file,
     if isequal(modeProcess,'legacy')
         disp('Reading in expression data!');
         tic
-            exp_file_tbl= readtable(exp_file,'FileType','text');
+            exp_file_tbl= readtable(exp_file,'FileType','text','PreserveVariableNames',1);
             SampleNames = exp_file_tbl.Properties.VariableNames;
             Exp         = exp_file_tbl{:,2:end};
             GeneNames   = exp_file_tbl{:,1};
@@ -164,7 +164,7 @@ function [GeneMotif,GeneNamesExp,TfMotif,TFNamesInit,NumConditions,...
     % Read expression
     disp('Reading in expression data!');
     tic
-        exp_file_tbl = readtable(exp_file,'FileType','text');
+        exp_file_tbl = readtable(exp_file,'FileType','text','PreserveVariableNames',1);
         SampleNames = exp_file_tbl.Properties.VariableNames;
         ExpInit      = exp_file_tbl{:,2:end};
         GeneNamesExp = exp_file_tbl{:,1};


### PR DESCRIPTION
@mararie in this PR, I added the option to save lioness networks as tables not matrices to allow:
- TF names in rows
- Gene names in columns
- sample names as file names

This was possible to the recent MATLAB update to relax variable name constraints.